### PR TITLE
Added ProductionRequires

### DIFF
--- a/src/Xeltec.Trade/Interfaces/IProductionRequires.cs
+++ b/src/Xeltec.Trade/Interfaces/IProductionRequires.cs
@@ -1,0 +1,12 @@
+﻿
+
+namespace Xeltec.Trade.Interfaces
+{
+    using Xeltec.Trade.Interfaces.TradeResources;
+
+    public interface IProductionRequires
+    {
+        ITradeItem ItemRequired { get; }
+        int QuantityRequired { get; }
+    }
+}

--- a/src/Xeltec.Trade/ProductionRequires.cs
+++ b/src/Xeltec.Trade/ProductionRequires.cs
@@ -1,0 +1,37 @@
+﻿
+namespace Xeltec.Trade
+{
+    using System;
+
+    using Xeltec.Trade.Interfaces;
+    using Xeltec.Trade.Interfaces.TradeResources;
+
+    public class ProductionRequires : IProductionRequires
+    {
+        public ProductionRequires(ITradeItem itemRequired, int quantityRequired)
+        {
+            if(itemRequired == null)
+            {
+                throw new ArgumentNullException(nameof(itemRequired));
+            }
+
+            if(quantityRequired <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(quantityRequired));
+            }
+
+            ItemRequired = itemRequired;
+            QuantityRequired = quantityRequired;
+        }
+
+        public ITradeItem ItemRequired
+        {
+            get; private set;
+        }
+
+        public int QuantityRequired
+        {
+            get; private set;
+        }
+    }
+}

--- a/src/Xeltec.Trade/Xeltec.Trade.csproj
+++ b/src/Xeltec.Trade/Xeltec.Trade.csproj
@@ -43,11 +43,13 @@
     <Compile Include="Factories\ProductionFactory.cs" />
     <Compile Include="Interfaces\Factories\IProductionFactory.cs" />
     <Compile Include="Interfaces\Factories\IResourceFactoryFactory.cs" />
+    <Compile Include="Interfaces\IProductionRequires.cs" />
     <Compile Include="Interfaces\IResourceFactoryConfiguration.cs" />
     <Compile Include="Interfaces\ITradableStock.cs" />
     <Compile Include="Interfaces\IProduction.cs" />
     <Compile Include="Production.cs" />
     <Compile Include="Factories\ResourceFactoryFactory.cs" />
+    <Compile Include="ProductionRequires.cs" />
     <Compile Include="ResourceFactoryConfiguration.cs" />
     <Compile Include="TradableStock.cs" />
     <Compile Include="TradeResources\Food.cs" />

--- a/tests/XeltecTradeTests/ProductionRequiresTests.cs
+++ b/tests/XeltecTradeTests/ProductionRequiresTests.cs
@@ -1,0 +1,94 @@
+﻿
+namespace XeltecTradeTests
+{
+    using System;
+
+    using Xeltec.Trade;
+    using Xeltec.Trade.Interfaces.TradeResources;
+    using Xeltec.Trade.TradeResources;
+
+    using Moq;
+    using Moq.AutoMock;
+    using Xunit;
+    
+    public class ProductionRequiresTests
+    {
+        private AutoMocker autoMocker;
+
+        public ProductionRequiresTests()
+        {
+            autoMocker = new AutoMocker();
+        }
+
+        [Fact]
+        public void CanCreateProductionRequired()
+        {
+            var mockTradeItem = autoMocker.GetMock<ITradeItem>();
+            var stubQuantityRequired = 1;
+
+            var sut = new Mock<ProductionRequires>(mockTradeItem, stubQuantityRequired);
+            Assert.NotNull(sut);
+        }
+
+        [Fact]
+        public void ThrowsArgumentNullExceptionWhenPassedNullTradeItem()
+        {
+            autoMocker.Use<ITradeItem>((ITradeItem)null);
+            autoMocker.Use<Int32>(1);
+
+            var exception = Record.Exception(() => autoMocker.CreateInstance<ProductionRequires>());
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentNullException>(exception);
+            Assert.Equal("itemRequired", ((ArgumentNullException)exception).ParamName);
+        }
+
+        [Fact]
+        public void ThrowsArgumentOutOfRangeExceptionWhenPassedZeroQuantityRequired()
+        {
+            autoMocker.Use<Int32>(0);
+
+            var exception = Record.Exception(() => autoMocker.CreateInstance<ProductionRequires>());
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentOutOfRangeException>(exception);
+            Assert.Equal("quantityRequired", ((ArgumentOutOfRangeException)exception).ParamName);
+        }
+
+        [Fact]
+        public void ThrowsArgumentOutOfRangeExceptionWhenPassedNegativeQuantityRequired()
+        {
+            autoMocker.Use<Int32>(-1);
+
+            var exception = Record.Exception(() => autoMocker.CreateInstance<ProductionRequires>());
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentOutOfRangeException>(exception);
+            Assert.Equal("quantityRequired", ((ArgumentOutOfRangeException)exception).ParamName);
+        }
+
+
+        [Fact]
+        public void UsesProvidedTradeItem()
+        {
+            var stubPower = new Power();
+            autoMocker.Use<ITradeItem>(stubPower);
+            autoMocker.Use<Int32>(1);
+
+            var sut = autoMocker.CreateInstance<ProductionRequires>();
+
+            Assert.Equal(stubPower, sut.ItemRequired);
+        }
+
+        [Fact]
+        public void UsesProvidedQuantityRequired()
+        {
+            var stubQuantityRequired = 1;
+            autoMocker.Use<Int32>(stubQuantityRequired);
+
+            var sut = autoMocker.CreateInstance<ProductionRequires>();
+
+            Assert.Equal(stubQuantityRequired, sut.QuantityRequired);
+        }
+    }
+}

--- a/tests/XeltecTradeTests/XeltecTradeTests.csproj
+++ b/tests/XeltecTradeTests/XeltecTradeTests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="LocationTests.cs" />
     <Compile Include="PowerTests.cs" />
     <Compile Include="ProductionFactoryTests.cs" />
+    <Compile Include="ProductionRequiresTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResourceFactoryTests.cs" />
     <Compile Include="TradeNetworkTests.cs" />


### PR DESCRIPTION
Production Requries can be constructed
Production Requires throws ArgumentNullException when provided ITradeItem is null
Production Requires throws ArgumentOutOfRangeException when provided quantity required is zero
Production Requires throws ArgumentOutOfRangeException when provided quantity required is less than zero
Production Requires uses provided ItemRequired
ProductionRequires uses provided QuantityRequired