### PR TITLE
Initial development to Staging

### DIFF
--- a/src/Xeltec.Trade.Console/Program.cs
+++ b/src/Xeltec.Trade.Console/Program.cs
@@ -39,7 +39,11 @@ namespace Xeltec.Trade.Console
                 Console.WriteLine(string.Format("Factory at [{0},{1}] has Credits: {2}", f.Location.X, f.Location.Y, f.Credits));
                 foreach(var resourceProduced in f.Production)
                 {
-                    Console.WriteLine(String.Format(" - Makes {0} units of {1}", resourceProduced.UnitsProducedPerTick, resourceProduced.TradeItem.Description));
+                    Console.WriteLine(String.Format(" - Makes {0} units of {1}", resourceProduced.UnitsProducedPerTick, resourceProduced.ItemProduced.Description));
+                    foreach(var productionRequires in resourceProduced.ProductionRequires)
+                    {
+                        Console.WriteLine(String.Format(" -- Requires {0} units of {1}", productionRequires.QuantityRequired, productionRequires.ItemRequired.Description));
+                    }
                 }
             }
         }

--- a/src/Xeltec.Trade/Factories/ProductionFactory.cs
+++ b/src/Xeltec.Trade/Factories/ProductionFactory.cs
@@ -2,6 +2,7 @@
 namespace Xeltec.Trade.Factories
 {
     using System;
+    using System.Collections.Generic;
 
     using Xeltec.Trade.Interfaces;
     using Xeltec.Trade.Interfaces.Factories;
@@ -21,13 +22,31 @@ namespace Xeltec.Trade.Factories
             switch(tradeItemProduced.GetType().Name)
             {
                 case nameof(Power):
-                    productionItem = new Production(tradeItemProduced, 2);
+                    var powerProductionRequires = new List<IProductionRequires>()
+                    {
+                        new ProductionRequires(new Water(), 1),
+                        new ProductionRequires(new Food(), 1)
+                    };
+
+                    productionItem = new Production(tradeItemProduced, 2, powerProductionRequires);
                     break;
                 case nameof(Water):
-                    productionItem = new Production(tradeItemProduced, 4);
+                    var waterProductionRequires = new List<IProductionRequires>()
+                    {
+                        new ProductionRequires(new Food(), 1),
+                        new ProductionRequires(new Power(), 1)
+                    };
+
+                    productionItem = new Production(tradeItemProduced, 4, waterProductionRequires);
                     break;
                 case nameof(Food):
-                    productionItem = new Production(tradeItemProduced, 5);
+                    var foodProductionRequires = new List<IProductionRequires>()
+                    {
+                        new ProductionRequires(new Water(), 1),
+                        new ProductionRequires(new Power(), 1)
+                    };
+
+                    productionItem = new Production(tradeItemProduced, 5, foodProductionRequires);
                     break;
                 default:
                     throw new ArgumentException("Unexpected Argument", nameof(tradeItemProduced));

--- a/src/Xeltec.Trade/Factories/ResourceFactoryFactory.cs
+++ b/src/Xeltec.Trade/Factories/ResourceFactoryFactory.cs
@@ -13,7 +13,7 @@ namespace Xeltec.Trade.Factories
     {
         public IResourceFactory Create(IResourceFactoryConfiguration resourceFactoryStartingConfiguration, ILocation location)
         {
-            IProduction<ITradeItem> test = new Production(new Power(), 5.0);
+            IProduction<ITradeItem> test = new Production(new Power(), 5.0, new List<IProductionRequires>());
 
             IList<IProduction<ITradeItem>> productionList = new List<IProduction<ITradeItem>>();
             productionList.Add(test);

--- a/src/Xeltec.Trade/Factories/ResourceFactoryFactory.cs
+++ b/src/Xeltec.Trade/Factories/ResourceFactoryFactory.cs
@@ -55,6 +55,8 @@ namespace Xeltec.Trade.Factories
 
                 IList<ITradableStock<ITradeItem>> tradableStockList = new List<ITradableStock<ITradeItem>>();
                 tradableStockList.Add(new TradableStock<ITradeItem>(new Power()));
+                tradableStockList.Add(new TradableStock<ITradeItem>(new Water()));
+                tradableStockList.Add(new TradableStock<ITradeItem>(new Food()));
 
                 var location = new Location(random.Next(0, 100), random.Next(0, 100));
 
@@ -65,4 +67,4 @@ namespace Xeltec.Trade.Factories
             return resourceFactories;
         }
     }
-}
+} 

--- a/src/Xeltec.Trade/Interfaces/IProduction.cs
+++ b/src/Xeltec.Trade/Interfaces/IProduction.cs
@@ -6,7 +6,7 @@ namespace Xeltec.Trade.Interfaces
     public interface IProduction<ITradeItem>
     {
         double UnitsProducedPerTick { get; }
-        ITradeItem TradeItem { get; }
+        ITradeItem ItemProduced { get; }
         IList<IProductionRequires> ProductionRequires { get; }
     }
 }

--- a/src/Xeltec.Trade/Interfaces/IProduction.cs
+++ b/src/Xeltec.Trade/Interfaces/IProduction.cs
@@ -1,9 +1,12 @@
 ﻿
 namespace Xeltec.Trade.Interfaces
 {
+    using System.Collections.Generic;
+
     public interface IProduction<ITradeItem>
     {
         double UnitsProducedPerTick { get; }
         ITradeItem TradeItem { get; }
+        IList<IProductionRequires> ProductionRequires { get; }
     }
 }

--- a/src/Xeltec.Trade/Interfaces/ITradableStock.cs
+++ b/src/Xeltec.Trade/Interfaces/ITradableStock.cs
@@ -9,5 +9,8 @@ namespace Xeltec.Trade.Interfaces
         double QuantityInStock { get; }
         double PricePerUnit { get; }
         T TradeItem { get; }
+
+        bool AddStock(double quantity);
+        bool RemoveStock(double quantity);
     }
 }

--- a/src/Xeltec.Trade/Production.cs
+++ b/src/Xeltec.Trade/Production.cs
@@ -1,22 +1,23 @@
 ﻿
 namespace Xeltec.Trade
 {
+    using System.Collections.Generic;
+
     using Xeltec.Trade.Interfaces;
     using Xeltec.Trade.Interfaces.TradeResources;
 
     public class Production : IProduction<ITradeItem>
     {
-        public Production(ITradeItem tradeItem, double unitsProducedPerTick)
+        public Production(ITradeItem tradeItem, double unitsProducedPerTick, IList<IProductionRequires> productionRequires)
         {
             TradeItem = tradeItem;
             UnitsProducedPerTick = unitsProducedPerTick;
         }
 
-        public double UnitsProducedPerTick
-        {
-            get; private set;
-        }
+        public double UnitsProducedPerTick { get; private set; }
 
         public ITradeItem TradeItem { get; private set; }
+
+        public IList<IProductionRequires> ProductionRequires { get; private set; }
     }
 }

--- a/src/Xeltec.Trade/Production.cs
+++ b/src/Xeltec.Trade/Production.cs
@@ -1,6 +1,7 @@
 ﻿
 namespace Xeltec.Trade
 {
+    using System;
     using System.Collections.Generic;
 
     using Xeltec.Trade.Interfaces;
@@ -8,15 +9,31 @@ namespace Xeltec.Trade
 
     public class Production : IProduction<ITradeItem>
     {
-        public Production(ITradeItem tradeItem, double unitsProducedPerTick, IList<IProductionRequires> productionRequires)
+        public Production(ITradeItem itemProduced, double unitsProducedPerTick, IList<IProductionRequires> productionRequires)
         {
-            TradeItem = tradeItem;
+            if(itemProduced == null)
+            {
+                throw new ArgumentNullException(nameof(itemProduced));
+            }
+
+            if(unitsProducedPerTick <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(unitsProducedPerTick));
+            }
+
+            if(productionRequires == null)
+            {
+                throw new ArgumentNullException(nameof(productionRequires));
+            }
+
+            ItemProduced = itemProduced;
             UnitsProducedPerTick = unitsProducedPerTick;
+            ProductionRequires = productionRequires;
         }
 
         public double UnitsProducedPerTick { get; private set; }
 
-        public ITradeItem TradeItem { get; private set; }
+        public ITradeItem ItemProduced { get; private set; }
 
         public IList<IProductionRequires> ProductionRequires { get; private set; }
     }

--- a/src/Xeltec.Trade/TradableStock.cs
+++ b/src/Xeltec.Trade/TradableStock.cs
@@ -1,6 +1,8 @@
 ﻿
 namespace Xeltec.Trade
 {
+    using System;
+
     using Xeltec.Trade.Interfaces;
     using Xeltec.Trade.Interfaces.TradeResources;
 
@@ -24,6 +26,34 @@ namespace Xeltec.Trade
         public T TradeItem
         {
             get; private set;
+        }
+
+        public bool AddStock(double quantity)
+        {
+            if(quantity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(quantity));
+            }
+            QuantityInStock += quantity;
+
+            return true;
+        }
+
+        public bool RemoveStock(double quantity)
+        {
+            if (quantity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(quantity));
+            }
+
+            if(quantity > QuantityInStock)
+            {
+                return false;
+            }
+
+            QuantityInStock -= quantity;
+
+            return true;
         }
     }
 }

--- a/tests/XeltecTradeTests/ProductionFactoryTests.cs
+++ b/tests/XeltecTradeTests/ProductionFactoryTests.cs
@@ -42,7 +42,7 @@ namespace XeltecTradeTests
 
             var result = sut.Create(stubPower);
 
-            Assert.IsAssignableFrom<Power>(result.TradeItem);
+            Assert.IsAssignableFrom<Power>(result.ItemProduced);
         }
 
         [Fact]

--- a/tests/XeltecTradeTests/ProductionTests.cs
+++ b/tests/XeltecTradeTests/ProductionTests.cs
@@ -1,0 +1,107 @@
+﻿
+namespace XeltecTradeTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Xeltec.Trade;
+    using Xeltec.Trade.Interfaces;
+
+    using Moq.AutoMock;
+    using Xunit;
+    using Xeltec.Trade.Interfaces.TradeResources;
+    public class ProductionTests
+    {
+        private AutoMocker autoMocker;
+
+        public ProductionTests()
+        {
+            autoMocker = new AutoMocker();
+        }
+
+        [Fact]
+        public void CanCreateProduction()
+        {
+            autoMocker.Use<Double>(1);
+
+            var sut = autoMocker.CreateInstance<Production>();
+            Assert.NotNull(sut);
+        }
+
+        [Fact]
+        public void ThrowsArgumentNullExceptionWhenPassedNullItemProduced()
+        {
+            autoMocker.Use<ITradeItem>((ITradeItem)null);
+            autoMocker.Use<Double>(1);
+
+            var exception = Record.Exception(() => autoMocker.CreateInstance<Production>());
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentNullException>(exception);
+            Assert.Equal("itemProduced", ((ArgumentNullException)exception).ParamName);
+        }
+
+        [Fact]
+        public void ThrowsArgumentOutOfRangeExceptionWhenPassedZeroUnitsProducedPerTick()
+        {
+            autoMocker.Use<Double>(0);
+
+            var exception = Record.Exception(() => autoMocker.CreateInstance<Production>());
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentOutOfRangeException>(exception);
+            Assert.Equal("unitsProducedPerTick", ((ArgumentOutOfRangeException)exception).ParamName);
+        }
+
+        [Fact]
+        public void ThrowsArgumentNullExceptionWhenPassedNullProductionRequiresList()
+        {
+            autoMocker.Use<IList<IProductionRequires>>((IList<IProductionRequires>)null);
+            autoMocker.Use<Double>(1);
+
+            var exception = Record.Exception(() => autoMocker.CreateInstance<Production>());
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentNullException>(exception);
+            Assert.Equal("productionRequires", ((ArgumentNullException)exception).ParamName);
+        }
+
+        [Fact]
+        public void UsesProvidedItemProduced()
+        {
+            var mockItemProduced = autoMocker.GetMock<ITradeItem>();
+            autoMocker.Use<Double>(1);
+
+            var sut = autoMocker.CreateInstance<Production>();
+
+            Assert.Equal(mockItemProduced.Object, sut.ItemProduced);
+        }
+
+        [Fact]
+        public void UsesProvidedUnitsProducedPerTick()
+        {
+            var stubUnitsProducedPerTick = 5;
+            autoMocker.Use<Double>(stubUnitsProducedPerTick);
+
+            var sut = autoMocker.CreateInstance<Production>();
+
+            Assert.Equal(stubUnitsProducedPerTick, sut.UnitsProducedPerTick);
+        }
+
+        [Fact]
+        public void UsesProvidedProductionRequires()
+        {
+            var mockItemRequired = autoMocker.GetMock<IProductionRequires>();
+            var stubProductionRequires = new List<IProductionRequires>() {
+                mockItemRequired.Object
+            };
+
+            autoMocker.Use<Double>(1);
+            autoMocker.Use<IList<IProductionRequires>>(stubProductionRequires);
+
+            var sut = autoMocker.CreateInstance<Production>();
+
+            Assert.Equal(stubProductionRequires, sut.ProductionRequires);
+        }
+    }
+}

--- a/tests/XeltecTradeTests/TradableStockTests.cs
+++ b/tests/XeltecTradeTests/TradableStockTests.cs
@@ -1,0 +1,114 @@
+﻿
+namespace XeltecTradeTests
+{
+    using System;
+
+    using Xeltec.Trade;
+    using Xeltec.Trade.Interfaces;
+    using Xeltec.Trade.Interfaces.TradeResources;
+
+    using Moq.AutoMock;
+    using Xunit;
+    
+    public class TradableStockTests
+    {
+        
+        private AutoMocker autoMocker;
+
+        public TradableStockTests()
+        {
+            autoMocker = new AutoMocker();
+        }
+
+        [Fact]
+        public void CanCreateTradableStock()
+        {
+            ITradableStock<ITradeItem> sut = autoMocker.CreateInstance<TradableStock<ITradeItem>>();
+            Assert.NotNull(sut);
+        }
+
+        [Theory]
+        [InlineData(10)]
+        public void AddStockAddsProvidedQuantity(int quantity)
+        {
+            var sut = autoMocker.CreateInstance<TradableStock<ITradeItem>>();
+
+            var initialStock = sut.QuantityInStock;
+            sut.AddStock(quantity);
+            var resultingstock = sut.QuantityInStock;
+
+            Assert.Equal(quantity, resultingstock - initialStock);
+        }
+
+        [Fact]
+        public void AddStockThrowsArgumentOutOfRangeExceptionWhenQuantityIsZero()
+        {
+            var sut = autoMocker.CreateInstance<TradableStock<ITradeItem>>();
+            var exception = Record.Exception(() => sut.AddStock(0));
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentOutOfRangeException>(exception);
+            Assert.Equal("quantity", ((ArgumentOutOfRangeException)exception).ParamName);
+        }
+
+        [Fact]
+        public void AddStockThrowsArgumentOutOfRangeExceotionWhenQuantityIsLessThanZero()
+        {
+            var sut = autoMocker.CreateInstance<TradableStock<ITradeItem>>();
+            var exception = Record.Exception(() => sut.AddStock(-1));
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentOutOfRangeException>(exception);
+            Assert.Equal("quantity", ((ArgumentOutOfRangeException)exception).ParamName);
+        }
+
+        [Theory]
+        [InlineData(10)]
+        public void RemoveStockRemovesProvidedQuantity(int quantity)
+        {
+            var sut = autoMocker.CreateInstance<TradableStock<ITradeItem>>();
+            sut.AddStock(quantity);
+
+            var initialStock = sut.QuantityInStock;
+            sut.RemoveStock(quantity);
+            var resultingstock = sut.QuantityInStock;
+
+            Assert.Equal(quantity, initialStock - resultingstock);
+        }
+
+        [Fact]
+        public void RemoveStockThrowsArgumentOutOfRangeExceptionWhenQuantityIsZero()
+        {
+            var sut = autoMocker.CreateInstance<TradableStock<ITradeItem>>();
+            var exception = Record.Exception(() => sut.RemoveStock(0));
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentOutOfRangeException>(exception);
+            Assert.Equal("quantity", ((ArgumentOutOfRangeException)exception).ParamName);
+        }
+
+        [Fact]
+        public void RemoveStockThrowsArgumentOutOfRangeExceotionWhenQuantityIsLessThanZero()
+        {
+            var sut = autoMocker.CreateInstance<TradableStock<ITradeItem>>();
+            var exception = Record.Exception(() => sut.RemoveStock(-1));
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentOutOfRangeException>(exception);
+            Assert.Equal("quantity", ((ArgumentOutOfRangeException)exception).ParamName);
+        }
+
+        [Fact]
+        public void RemoveStockReturnsFalseWhenQuantityInStockIsLessThanQuantityRemoved()
+        {
+            var sut = autoMocker.CreateInstance<TradableStock<ITradeItem>>();
+
+            var initialStock = sut.QuantityInStock;
+            var quantity = initialStock + 1;
+
+            var result = sut.RemoveStock(quantity);
+            Assert.False(result);
+            Assert.Equal(initialStock, sut.QuantityInStock);
+        }
+    }
+}

--- a/tests/XeltecTradeTests/XeltecTradeTests.csproj
+++ b/tests/XeltecTradeTests/XeltecTradeTests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="ProductionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResourceFactoryTests.cs" />
+    <Compile Include="TradableStockTests.cs" />
     <Compile Include="TradeNetworkTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/XeltecTradeTests/XeltecTradeTests.csproj
+++ b/tests/XeltecTradeTests/XeltecTradeTests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="PowerTests.cs" />
     <Compile Include="ProductionFactoryTests.cs" />
     <Compile Include="ProductionRequiresTests.cs" />
+    <Compile Include="ProductionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResourceFactoryTests.cs" />
     <Compile Include="TradeNetworkTests.cs" />


### PR DESCRIPTION
Production of resources now uses new ProductionRequires class			
Production can be constructed …
Production throws ArgumentNullException when passed null ItemProduced
Production throws ArgumentOutOfRangeException when passed zero UnitsProducedPerTick
Production throws ArgumentNullException when passed null ProductionRequires list
Production uses provided ItemProduced
Production uses provided ProductionRequires
Production uses provided UnitsProducedPerTick
all resource factories can trade all types of stock
TradableStock updates …
Can create TradableStock
AddStock adds provided quantity
AddStock throws ArgumentOutOfRangeException when provided quantity is zero
AddStock throws ArgumentOutOfRangeException when provided quantity is less than zero
RemoveStock removes provided quantity
RemoveStock throws ArgumentOutOfRangeException when provided quantity is zero
RemoveStock throws ArgumentOurOfRangeException when provided quantity is less than zero
RemoveStock returns false when QuantityInStock is less than quantity removed